### PR TITLE
Improve database security

### DIFF
--- a/instant.perms.ts
+++ b/instant.perms.ts
@@ -6,9 +6,25 @@ const rules = {
     $default: {
         allow: {
             view: "true",
-            create: "true",
-            delete: "true",
-            update: "true",
+            create: "false",
+            update: "false",
+            delete: "false",
+        },
+    },
+    dollars: {
+        allow: {
+            view: "true",
+            create: "false",
+            update: "false",
+            delete: "false",
+        },
+    },
+    displayNames: {
+        allow: {
+            view: "true",
+            create: "false",
+            update: "false",
+            delete: "false",
         },
     },
 } satisfies InstantRules;

--- a/src/components/record-donation.tsx
+++ b/src/components/record-donation.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { db } from "@/lib/instantdb";
-import { id } from "@instantdb/react";
+
 
 type RecordDonationProps = {
     customerId: string;
@@ -16,17 +15,24 @@ export default function RecordDonation({ customerId }: RecordDonationProps) {
     useEffect(() => {
         if (hasRun.current) return;
         hasRun.current = true;
-        if (customerId) {
-            db.transact(
-                db.tx.dollars[id()].update({
-                    userId: customerId,
-                    createdAt: Date.now(),
-                    used: false,
-                    usedFor: "",
-                })
-            );
-        }
-        router.push("/thank-you");
+        const record = async () => {
+            if (customerId) {
+                try {
+                    await fetch("/return/record-dollar", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                            userId: customerId,
+                            createdAt: Date.now(),
+                        }),
+                    });
+                } catch (err) {
+                    console.error("Error recording donation", err);
+                }
+            }
+            router.push("/thank-you");
+        };
+        record();
     }, [customerId, router]);
 
     return (


### PR DESCRIPTION
## Summary
- lock down InstantDB rules so clients can only read data
- record Stripe dollars through a server action instead of direct client writes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685c2cf5f7448332b03d89bb0e47dbbb